### PR TITLE
Support ZEN71 800LR model, support selection of multiple ZEN71 switches 

### DIFF
--- a/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+++ b/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: Zooz ZEN71
-  description: BN Updates Automations helper for the Zooz ZEN71 Switch using the Zwave JS integration.
+  description: Automations helper for the Zooz ZEN71 Switch using the Zwave JS integration. Allows for multiple switches to be selected.
   domain: automation
   input:
     zooz_zen71:
@@ -102,7 +102,7 @@ blueprint:
       default: []
       selector:
         action: {}
-  source_url: https://github.com/b-neufeld/Home-AssistantConfig/blob/master/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+  source_url: https://github.com/austinmroczek/Home-AssistantConfig/blob/master/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
 mode: single
 max_exceeded: silent
 variables:

--- a/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+++ b/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
@@ -10,7 +10,9 @@ blueprint:
         device:
           integration: zwave_js
           manufacturer: Zooz
-          model: ZEN71
+          filter:
+          - model: ZEN71
+          - model: ZEN71 800LR
     switch_up_1x:
       name: Top Paddle 1x
       description: 'Action to run on switch upper paddle single tap. Default: Turn

--- a/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+++ b/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
@@ -105,6 +105,8 @@ blueprint:
   source_url: https://community.home-assistant.io/t/zooz-zen30-double-switch-automation-helper/281362
 mode: single
 max_exceeded: silent
+variables:
+  device_id: !input 'zooz_zen71'
 trigger:
 - platform: event
   event_type: zwave_js_value_notification

--- a/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+++ b/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
@@ -13,6 +13,7 @@ blueprint:
           filter:
           - model: ZEN71
           - model: ZEN71 800LR
+          multiple: true
     switch_up_1x:
       name: Top Paddle 1x
       description: 'Action to run on switch upper paddle single tap. Default: Turn

--- a/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+++ b/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: Zooz ZEN71
-  description: BN Updates: Automations helper for the Zooz ZEN71 Switch using the Zwave JS integration.
+  description: BN Updates Automations helper for the Zooz ZEN71 Switch using the Zwave JS integration.
   domain: automation
   input:
     zooz_zen71:

--- a/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
+++ b/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: Zooz ZEN71
-  description: Automations helper for the Zooz ZEN71 Switch using the Zwave JS integration.
+  description: BN Updates: Automations helper for the Zooz ZEN71 Switch using the Zwave JS integration.
   domain: automation
   input:
     zooz_zen71:
@@ -102,7 +102,7 @@ blueprint:
       default: []
       selector:
         action: {}
-  source_url: https://community.home-assistant.io/t/zooz-zen30-double-switch-automation-helper/281362
+  source_url: https://github.com/b-neufeld/Home-AssistantConfig/blob/master/blueprints/automation/zooz-zen71-switch-automation-helper.yaml
 mode: single
 max_exceeded: silent
 variables:
@@ -110,9 +110,10 @@ variables:
 trigger:
 - platform: event
   event_type: zwave_js_value_notification
-  event_data:
-    command_class_name: Central Scene
-    device_id: !input 'zooz_zen71'
+  #event_data:
+  #  command_class_name: Central Scene
+  #  device_id: !input 'zooz_zen71'
+condition: '{{ trigger.event.data.device_id in device_id }}'
 action:
 - variables:
     scene_id: '{{ trigger.event.data.label }}'


### PR DESCRIPTION
Tweaked your script (which I found linked on the Home Assistant forums) to support selection of multiple switches, as well as to let it "find" the 800LR model. 

Borrowed the multiple switch idea from a similar script for Inovelli switches. It's nice because one automation can handle every light switch where you want the same scenes/actions. 

I don't github often so sorry if this pull request is unwelcome or wrong somehow! 